### PR TITLE
add python best practice &  remove readlines()

### DIFF
--- a/docs/p.md
+++ b/docs/p.md
@@ -18,6 +18,7 @@
 * [python-strfttime](https://github.com/mccutchen/strftime.org)
 * [python-cheat-sheet](http://www.addedbytes.com/cheat-sheets/python-cheat-sheet/)
 * [python feature](https://github.com/PythonCharmers/python-future)
+* [python-best-practice](http://python-best-practice.liujiacai.net/)
 
 ###flask
 * [flask](https://docs.google.com/file/d/1pnwfq8v5Ph4Xn8ttv9P_TLnrRbT9-S_v-KdZiEcx64vlGYkC0SoMfZOs0NYN/edit?usp=drive_web)

--- a/tests/url_validate.py
+++ b/tests/url_validate.py
@@ -7,16 +7,18 @@
 
 import re
 import sys
+import os
 
 from requests import get
 from requests.exceptions import ConnectionError, MissingSchema
 
 url_re = re.compile('.*\[.*\]\((.*)\)')
+current_dir = os.path.dirname(os.path.realpath(__file__))
 
 for i in range(ord('a'), ord('z')+1):
-    file = 'docs/{alphabet}.md'.format(alphabet=chr(i))
+    file = '{current_dir}/../docs/{alphabet}.md'.format(current_dir=current_dir, alphabet=chr(i))
     with open(file) as f:
-        for line, content in enumerate(f.readlines()):
+        for line, content in enumerate(f):
             m = re.match(url_re, content)
             if m is None:
                 continue


### PR DESCRIPTION
Update : 

1. add python best practice
2. remove `readlines()` because file objects are iterators so `readlines()` is both unnecessary and low-effective when iterate in for loop