### PR TITLE
Update Head Tags --> <head> Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Inspired by [@sindresorhus](https://github.com/sindresorhus) [awesome](https://g
 - [underscore-cheat-sheet](http://f.cl.ly/items/093o0l2Y3u130y0W0c0x/underscore-cheat-sheet.pdf)
 - [es6-cheatsheet](https://github.com/DrkSephy/es6-cheatsheet)
 - [webpack](https://github.com/petehunt/webpack-howto)
-- [head tags](http://headtags.info/)
+- [\<head> Cheat Sheet](http://gethead.info/)
 
 ## Back-End Development
 


### PR DESCRIPTION
I own both headtags.info & gethead.info domains. Currently headtags.info redirects to gethead.info. I intend to let the headtags.info domain expire, so gethead.info is the canonical URL. Thanks!