### PR TITLE
Add Eclipse

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Inspired by [@sindresorhus](https://github.com/sindresorhus) [awesome](https://g
     - [Windows/Linux](https://resources.jetbrains.com/assets/products/intellij-idea/IntelliJIDEA_ReferenceCard.pdf)
     - [Mac OS X](https://resources.jetbrains.com/assets/products/intellij-idea/IntelliJIDEA_ReferenceCard_mac.pdf)
 - [MarkDown Cheat Sheet](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
+- [Eclipse](https://github.com/pellaton/eclipse-cheatsheet)
 
 ## Tools
 


### PR DESCRIPTION
Add Eclipse cheat sheet to the editors section. Covers Eclipse 3.x and 4.x.