### PR TITLE
Add Atom cheatsheet to editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Inspired by [@sindresorhus](https://github.com/sindresorhus) [awesome](https://g
     - [Mac OS X](https://resources.jetbrains.com/assets/products/intellij-idea/IntelliJIDEA_ReferenceCard_mac.pdf)
 - [MarkDown Cheat Sheet](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
 - [Eclipse](https://github.com/pellaton/eclipse-cheatsheet)
+- [Atom](https://github.com/nwinkler/atom-keyboard-shortcuts)
 
 ## Tools
 


### PR DESCRIPTION
Add Atom cheat sheet to the editors section. Covers *nix & Windows!