### PR TITLE
Readme: update Redux cheatsheet URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Inspired by [@sindresorhus](https://github.com/sindresorhus) [awesome](https://g
 - [react-cheatsheet](https://reactcheatsheet.com/)
 - [react-native-cheat-sheet](https://github.com/refinery29/react-native-cheat-sheet)
 - [react-native-styling-cheat-sheet](https://github.com/vhpoet/react-native-styling-cheat-sheet)
-- [redux](http://ricostacruz.com/cheatsheets/redux.html)
+- [redux](https://devhints.io/redux)
 - [underscore-cheat-sheet](http://f.cl.ly/items/093o0l2Y3u130y0W0c0x/underscore-cheat-sheet.pdf)
 - [webpack](https://github.com/petehunt/webpack-howto)
 - [\<head> Cheat Sheet](http://gethead.info/)


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) See: https://devhints.io/redux

Btw, there's also many pages in the site that can fit into awesome-cheatsheet:

- https://devhints.io/react
- https://devhints.io/sass
- https://devhints.io/go
- https://devhints.io/css
- ...and a whole other bunch, really