### PR TITLE
Updated the link for Kanban cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Inspired by [@sindresorhus](https://github.com/sindresorhus) [awesome](https://g
 
 - [Agile Cheatsheet](http://cheatsheetworld.com/programming/agile-development-cheat-sheet/)
 - [Scrum Cheatsheet](https://www.axosoft.com/Downloads/Scrum_Diagram.pdf)
-- [Kanban Cheatsheet](http://www.eylean.com/blog/wp-content/uploads/2017/05/Kanban-Cheat-Sheet.png)
+- [Kanban Cheatsheet](https://teamhood.com/wp-content/uploads/2022/11/Kanban-Cheat-Sheet.png)
 - [Lean Cheatsheet](https://www.cheatography.com/davidpol/cheat-sheets/lean-methodology/pdf_bw/)
 - [A set of metodologies in one Cheatsheet (waterfall, agile, lean, xp, etc)](https://www.cheatography.com/nataliemoore/cheat-sheets/system-development-methodologies/pdf_bw/)
 


### PR DESCRIPTION
The cheat sheet page was moved from eylean.com to teamhood.com and this is where you will find the latest version from now on. This was done, because Eylean board is no longer being developed and we are focusing solely on Teamhood.


Hello! Before sending a PR please note the following:

- make sure the adding cheat-sheet is not in README.md :rocket: 

Thanks!

